### PR TITLE
Fix Python bindings; attribute name change

### DIFF
--- a/bindings/python/mpq.py
+++ b/bindings/python/mpq.py
@@ -95,7 +95,7 @@ class Reader(object):
         elif whence == os.SEEK_CUR:
             offset += self._pos
         elif whence == os.SEEK_END:
-            offset += self._file.unpacked_size
+            offset += self._file.size_unpacked
         else:
             raise ValueError, "invalid whence"
         
@@ -176,8 +176,8 @@ class File(object):
         self.number = number
         
         for name, atype in [
-            ("packed_size", ctypes.c_uint64),
-            ("unpacked_size", ctypes.c_uint64),
+            ("size_packed", ctypes.c_uint64),
+            ("size_unpacked", ctypes.c_uint64),
             ("offset", ctypes.c_uint64),
             ("blocks", ctypes.c_uint32),
             ("encrypted", ctypes.c_uint32),
@@ -190,7 +190,7 @@ class File(object):
             setattr(self, name, data.value)
     
     def __str__(self, ctypes=ctypes, libmpq=libmpq):
-        data = ctypes.create_string_buffer(self.unpacked_size)
+        data = ctypes.create_string_buffer(self.size_unpacked)
         libmpq.libmpq__file_read(self._archive._mpq, self.number,
             data, ctypes.c_uint64(len(data)), None)
         return data.raw
@@ -221,8 +221,8 @@ class Archive(object):
         self._opened = True
         
         for field_name, field_type in [
-            ("packed_size", ctypes.c_uint64),
-            ("unpacked_size", ctypes.c_uint64),
+            ("size_packed", ctypes.c_uint64),
+            ("size_unpacked", ctypes.c_uint64),
             ("offset", ctypes.c_uint64),
             ("version", ctypes.c_uint32),
             ("files", ctypes.c_uint32),
@@ -308,7 +308,7 @@ if __name__ == "__main__":
         d = "".join(d)
         
         assert a == b == c == d, map(hash, [a,b,c,d])
-        assert len(a) == file.unpacked_size
+        assert len(a) == file.size_unpacked
         
         repr(iter(file))
         


### PR DESCRIPTION
At some point it seems that some function names changed slightly and the Python wrapper broke. This simply renames the Python attributes to match the library function names.
