### PR TITLE
archive_open: Return LIBMPQ_ERROR_EXIST on ENOENT

### DIFF
--- a/libmpq/mpq.c
+++ b/libmpq/mpq.c
@@ -29,6 +29,7 @@
 #include "common.h"
 
 /* generic includes. */
+#include <errno.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
@@ -91,10 +92,11 @@ int32_t libmpq__archive_open(mpq_archive_s **mpq_archive, const char *mpq_filena
 	}
 
 	/* check if file exists and is readable */
+	errno = 0;
 	if (((*mpq_archive)->fp = fopen(mpq_filename, "rb")) == NULL) {
 
 		/* file could not be opened. */
-		result = LIBMPQ_ERROR_OPEN;
+		result = errno == ENOENT ? LIBMPQ_ERROR_EXIST : LIBMPQ_ERROR_OPEN;
 		goto error;
 	}
 

--- a/libmpq/mpq.h
+++ b/libmpq/mpq.h
@@ -52,7 +52,7 @@ extern "C" {
 #define LIBMPQ_ERROR_FORMAT			-7		/* format errror. */
 #define LIBMPQ_ERROR_NOT_INITIALIZED		-8		/* libmpq__init() wasn't called. */
 #define LIBMPQ_ERROR_SIZE			-9		/* buffer size is to small. */
-#define LIBMPQ_ERROR_EXIST			-10		/* file or block does not exist in archive. */
+#define LIBMPQ_ERROR_EXIST			-10		/* archive does not exist, or file or block does not exist in archive. */
 #define LIBMPQ_ERROR_DECRYPT			-11		/* we don't know the decryption seed. */
 #define LIBMPQ_ERROR_UNPACK			-12		/* error on unpacking file. */
 


### PR DESCRIPTION
This is useful for clients that look for archives in multiple places to
distinguish file-not-found from other errors.

Fixes #4