### PR TITLE
Fix `-Waddress-of-packed-member`

### DIFF
--- a/libmpq/mpq.c
+++ b/libmpq/mpq.c
@@ -693,12 +693,14 @@ int32_t libmpq__block_open_offset(mpq_archive_s *mpq_archive, uint32_t file_numb
 		if (mpq_archive->mpq_block[mpq_archive->mpq_map[file_number].block_table_indices].flags & LIBMPQ_FLAG_ENCRYPTED) {
 
 			/* check if we don't know the file seed, try to find it. */
-			if (libmpq__decrypt_key((uint8_t *)mpq_archive->mpq_file[file_number]->packed_offset, packed_size, mpq_archive->block_size, &mpq_archive->mpq_file[file_number]->seed) < 0) {
+			uint32_t seed;
+			if (libmpq__decrypt_key((uint8_t *)mpq_archive->mpq_file[file_number]->packed_offset, packed_size, mpq_archive->block_size, &seed) < 0) {
 
 				/* sorry without seed, we cannot extract file. */
 				result = LIBMPQ_ERROR_DECRYPT;
 				goto error;
 			}
+			mpq_archive->mpq_file[file_number]->seed = seed;
 
 			/* decrypt block in input buffer. */
 			if (libmpq__decrypt_block(mpq_archive->mpq_file[file_number]->packed_offset, packed_size, mpq_archive->mpq_file[file_number]->seed - 1) < 0 ) {


### PR DESCRIPTION
Fixes the following warning:

    mpq.c: In function ‘libmpq__block_open_offset’:
    mpq.c:698:128: warning: taking address of packed member of ‘struct <anonymous>’ may result in an unaligned pointer value [-Waddress-of-packed-member]
      698 | pq__decrypt_key((uint8_t *)mpq_archive->mpq_file[file_number]->packed_offset, packed_size, mpq_archive->block_size, &mpq_archive->mpq_file[file_number]->seed) < 0) {
          |                                                                                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Fixes #3